### PR TITLE
Make constructor work without config param.

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -46,7 +46,7 @@ export class AuthConfig {
         this.globalHeaders = config.globalHeaders || [];
         this.headerName = config.headerName || 'Authorization';
         if (config.headerPrefix) {
-            this.headerPrefix = config.headerPrefix + ' ';
+            this.headerPrefix = config.headerPrefix;
         } else if (config.noTokenScheme) {
             this.headerPrefix = '';
         } else {

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -55,8 +55,8 @@ export class AuthConfig {
         this.noJwtError = config.noJwtError || false;
         this.noTokenScheme = config.noTokenScheme || false;
         this.guards = {
-            loggedInGuard: config.guards.loggedInGuard || { redirectUrl: null },
-            loggedOutGuard: config.guards.loggedOutGuard || { redirectUrl: null }
+            loggedInGuard: (config.guards && config.guards.loggedInGuard) || { redirectUrl: null },
+            loggedOutGuard: (config.guards && config.guards.loggedOutGuard) || { redirectUrl: null }
         };
     }
 


### PR DESCRIPTION
When calling "AuthModule.forRoot()" without config argument, an exception is thrown when accessing config.guards.logged(In|Out)Guard. Added check for that.
